### PR TITLE
Fixes to get initially running

### DIFF
--- a/ONFTappingApp.config
+++ b/ONFTappingApp.config
@@ -4,6 +4,5 @@
 MongoDBPort=27017
 MongoDBUsername=
 MongoDBPassword=
-www-rootdir=/home/wiretap/ONF-ODL/OpenDaylight/controller/opendaylight/distribution/opendaylight/target/distribution.opendaylight-os
-gipackage/opendaylight/www/app
+www-rootdir=/home/odl/controller/opendaylight/samples/SampleTap/web-ui/tapping-ui_2.6
 # End of file

--- a/src/main/java/org/opendaylight/controller/samples/#license.txt#
+++ b/src/main/java/org/opendaylight/controller/samples/#license.txt#
@@ -2,8 +2,8 @@
 
 Copyright Å©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/add-license.sh
+++ b/src/main/java/org/opendaylight/controller/samples/add-license.sh
@@ -2,5 +2,5 @@
 
 for filename in *.java
 do
-  cat ../license.txt $filename > new/$filename 
+  cat ../license.txt $filename > new/$filename
 done

--- a/src/main/java/org/opendaylight/controller/samples/license.txt
+++ b/src/main/java/org/opendaylight/controller/samples/license.txt
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/AddressDesc.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/AddressDesc.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/CaptureDev.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/CaptureDev.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/CaptureTypeEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/CaptureTypeEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/DBAuthenticationException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/DBAuthenticationException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/DBTableChangeEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/DBTableChangeEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/DatabaseConnectException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/DatabaseConnectException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/DatabaseNames.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/DatabaseNames.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/DuplicateEntryException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/DuplicateEntryException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/EntryField.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/EntryField.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/InconsistentDatabaseException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/InconsistentDatabaseException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/LinkStateEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/LinkStateEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/LoggedMessage.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/LoggedMessage.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/LoggingLevelEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/LoggingLevelEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/MatchCriteria.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/MatchCriteria.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/MatchField.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/MatchField.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/NextHopSwitch.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/NextHopSwitch.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/NotFoundException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/NotFoundException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitch.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitch.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitchIsAssignedException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitchIsAssignedException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitchIsNotAssignedException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitchIsNotAssignedException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitchNotFoundException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/OPFSwitchNotFoundException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/ObjectInUseException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/ObjectInUseException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortChain.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortChain.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortDescription.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortDescription.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortRange.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortRange.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortRangeList.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortRangeList.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortStatistics.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortStatistics.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortStatus.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortStatus.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortTypeEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/PortTypeEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/ReferenceCountEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/ReferenceCountEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/RewriteParams.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/RewriteParams.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/Router.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/Router.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/RouterLauncher.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/RouterLauncher.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchAndPort.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchAndPort.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchEntry.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchEntry.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchInfo.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchInfo.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchVersionEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/SwitchVersionEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TapAppException.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TapAppException.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TapPolicy.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TapPolicy.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TapPolicySummary.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TapPolicySummary.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingApp.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingApp.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.
@@ -122,7 +122,7 @@ public class TappingApp {
             try {
                     loadConfigurationFromFile();
             } catch (IOException e) {
-                    logger.error(fatal, "Unable to load ONS Tapping Application configuration file");
+                    logger.error(fatal, "Unable to load ONF Tapping Application configuration file");
                     logger.debug("Exception:", e);
                     return;
             }
@@ -158,7 +158,7 @@ public class TappingApp {
             try {
                 saveConfigurationToFile();
             } catch (IOException e) {
-                logger.error("Unable to save ONS Tapping Application configuration file");
+                logger.error("Unable to save ONF Tapping Application configuration file");
                 logger.debug("Exception:", e);
             }
         }
@@ -204,7 +204,7 @@ public class TappingApp {
 
         private void loadConfigurationFromFile() throws IOException {
             // now load properties from last invocation
-            FileInputStream in  = new FileInputStream("ONSTappingApp.config");
+            FileInputStream in  = new FileInputStream("ONFTappingApp.config");
             applicationProps.load(in);
             in.close();
 
@@ -221,7 +221,7 @@ public class TappingApp {
 
         // Store the application properties to the configuration file
         private static void saveConfigurationToFile() throws IOException {
-            FileOutputStream out = new FileOutputStream("ONSTappingApp.config");
+            FileOutputStream out = new FileOutputStream("ONFTappingApp.config");
 
             Properties properties = new Properties();
             properties.setProperty("MongoDBUsername", mongoDBUsername);
@@ -230,7 +230,7 @@ public class TappingApp {
             String mongoPort = Integer.toString(TappingApp.getMongoDBPort());
             properties.setProperty("MongoDBPort", mongoPort);
 
-            properties.store(out, "Settings for the ONS Tapping Application");
+            properties.store(out, "Settings for the ONF Tapping Application");
             out.close();
         }
 

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingAppHandler.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingAppHandler.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingAppLogic.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingAppLogic.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingModeEnum.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingModeEnum.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingRoute.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/TappingRoute.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/internal/Activator.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/internal/Activator.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.

--- a/src/main/java/org/opendaylight/controller/samples/onftappingapp/internal/ONFTappingAppImpl.java
+++ b/src/main/java/org/opendaylight/controller/samples/onftappingapp/internal/ONFTappingAppImpl.java
@@ -2,8 +2,8 @@
 
 Copyright ©2014 Open Networking Foundation
 
-This ONF SampleTap software is licensed under the Apache License, 
-Version 2.0 (the "License"); you may not use this file except in 
+This ONF SampleTap software is licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the original
 license at http://www.apache.org/licenses/LICENSE-2.0 and also in
 the main directory of the source distribution.
@@ -45,6 +45,7 @@ import org.opendaylight.controller.switchmanager.SwitchConfig;
 import org.opendaylight.controller.samples.onftappingapp.DBAuthenticationException;
 import org.opendaylight.controller.samples.onftappingapp.DatabaseConnectException;
 import org.opendaylight.controller.samples.onftappingapp.TappingApp;
+import org.opendaylight.controller.samples.onftappingapp.Router;
 
 /**
  * This class implements port tapping for hosts connected to the managed devices.


### PR DESCRIPTION
Fix files with extra spacing. Lots of complaints from checkstyle.
Fix missing import in internal/ONFTappingAppImpl.java
Fix reference to wrong ONFTappingApp.config file name in TappingApp.java
